### PR TITLE
Adds some base playwright tests

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -26,3 +26,16 @@ jobs:
           } catch {
             Write-Error $_
           }
+
+  test_e2e:
+    name: Run playwright tests
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-node@v3
+        with:
+          node-verison: 20
+          cache: npm
+      - run: npm ci
+      - run: npx playwright install --with-deps
+      - run: npm run e2e

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 node_modules
 .env
 dist
+test-results/

--- a/README.md
+++ b/README.md
@@ -99,6 +99,25 @@ npm start
 
 Once started the site should be accessible at `http://localhost:3000`, unless the console tells you another port to use.
 
+### Running the integration tests
+
+We have a suite of [Playwright](https://playwright.dev/) tests, which runs the website in a real browser and runs our assertions.
+
+- Install playwright
+```shell
+npx playwright install
+```
+
+- Run the tests
+```shell
+npm run e2e
+```
+
+During development, you may want to see the Playwright UI:
+```shell
+npm run e2e -- --ui
+```
+
 ### Add New Pages
 
 Astro is really great at adding new pages. This site is setup to either take an Astro file (eg. `src/pages/translations.astro`) or a markdown file (eg. `src/pages/about.md`). If it's a simple content page, markdown works fine, if there's a bit more to it or you want to add styles to it then an Astro file is the best option.

--- a/package-lock.json
+++ b/package-lock.json
@@ -13,6 +13,7 @@
       },
       "devDependencies": {
         "@astrojs/react": "^1.2.2",
+        "@playwright/test": "^1.45.3",
         "postcss-import": "^15.0.0",
         "postcss-nesting": "^10.2.0",
         "react": "^18.2.0",
@@ -657,6 +658,21 @@
       },
       "funding": {
         "url": "https://opencollective.com/unts"
+      }
+    },
+    "node_modules/@playwright/test": {
+      "version": "1.45.3",
+      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.45.3.tgz",
+      "integrity": "sha512-UKF4XsBfy+u3MFWEH44hva1Q8Da28G6RFtR2+5saw+jgAFQV5yYnB1fu68Mz7fO+5GJF3wgwAIs0UelU8TxFrA==",
+      "dev": true,
+      "dependencies": {
+        "playwright": "1.45.3"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/@polka/url": {
@@ -4305,6 +4321,50 @@
         "node": ">=8"
       }
     },
+    "node_modules/playwright": {
+      "version": "1.45.3",
+      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.45.3.tgz",
+      "integrity": "sha512-QhVaS+lpluxCaioejDZ95l4Y4jSFCsBvl2UZkpeXlzxmqS+aABr5c82YmfMHrL6x27nvrvykJAFpkzT2eWdJww==",
+      "dev": true,
+      "dependencies": {
+        "playwright-core": "1.45.3"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "fsevents": "2.3.2"
+      }
+    },
+    "node_modules/playwright-core": {
+      "version": "1.45.3",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.45.3.tgz",
+      "integrity": "sha512-+ym0jNbcjikaOwwSZycFbwkWgfruWvYlJfThKYAlImbxUgdWFO2oW70ojPm4OpE4t6TAo2FY/smM+hpVTtkhDA==",
+      "dev": true,
+      "bin": {
+        "playwright-core": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/playwright/node_modules/fsevents": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
+      "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+      "dev": true,
+      "hasInstallScript": true,
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
     "node_modules/postcss": {
       "version": "8.4.38",
       "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.4.38.tgz",
@@ -6758,6 +6818,15 @@
       "resolved": "https://registry.npmjs.org/@pkgr/core/-/core-0.1.1.tgz",
       "integrity": "sha512-cq8o4cWH0ibXh9VGi5P20Tu9XF/0fFXl9EUinr9QfTM7a7p0oTA4iJRCQWppXR1Pg8dSM0UCItCkPwsk9qWWYA=="
     },
+    "@playwright/test": {
+      "version": "1.45.3",
+      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.45.3.tgz",
+      "integrity": "sha512-UKF4XsBfy+u3MFWEH44hva1Q8Da28G6RFtR2+5saw+jgAFQV5yYnB1fu68Mz7fO+5GJF3wgwAIs0UelU8TxFrA==",
+      "dev": true,
+      "requires": {
+        "playwright": "1.45.3"
+      }
+    },
     "@polka/url": {
       "version": "1.0.0-next.21",
       "resolved": "https://registry.npmjs.org/@polka/url/-/url-1.0.0-next.21.tgz",
@@ -9130,6 +9199,31 @@
           }
         }
       }
+    },
+    "playwright": {
+      "version": "1.45.3",
+      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.45.3.tgz",
+      "integrity": "sha512-QhVaS+lpluxCaioejDZ95l4Y4jSFCsBvl2UZkpeXlzxmqS+aABr5c82YmfMHrL6x27nvrvykJAFpkzT2eWdJww==",
+      "dev": true,
+      "requires": {
+        "fsevents": "2.3.2",
+        "playwright-core": "1.45.3"
+      },
+      "dependencies": {
+        "fsevents": {
+          "version": "2.3.2",
+          "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
+          "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+          "dev": true,
+          "optional": true
+        }
+      }
+    },
+    "playwright-core": {
+      "version": "1.45.3",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.45.3.tgz",
+      "integrity": "sha512-+ym0jNbcjikaOwwSZycFbwkWgfruWvYlJfThKYAlImbxUgdWFO2oW70ojPm4OpE4t6TAo2FY/smM+hpVTtkhDA==",
+      "dev": true
     },
     "postcss": {
       "version": "8.4.38",

--- a/package.json
+++ b/package.json
@@ -7,7 +7,8 @@
     "dev": "astro dev",
     "build": "astro build",
     "preview": "astro preview",
-    "start": "npm run dev"
+    "start": "npm run dev",
+    "e2e": "npx playwright test"
   },
   "repository": {
     "type": "git",
@@ -25,6 +26,7 @@
   },
   "devDependencies": {
     "@astrojs/react": "^1.2.2",
+    "@playwright/test": "^1.45.3",
     "postcss-import": "^15.0.0",
     "postcss-nesting": "^10.2.0",
     "react": "^18.2.0",

--- a/playwright.config.js
+++ b/playwright.config.js
@@ -1,0 +1,12 @@
+import { defineConfig } from "@playwright/test";
+
+export default defineConfig({
+  use: {
+    baseURL: "http://localhost:3000",
+  },
+  webServer: {
+    command: "npm run start",
+    port: 3000,
+    reuseExistingServer: true,
+  },
+});

--- a/src/components/client/Search.jsx
+++ b/src/components/client/Search.jsx
@@ -21,7 +21,7 @@ const getTranslationsForLanguages = (fromLang, toLang, word) => {
             {
                 const translateFrom = translationsCategory[fromLang];
                 const translateTo = translationsCategory[toLang];
-
+                
                 // define a dictionary to return as value
                 const relevantTranslations = {};
                 Object.keys(translateFrom).forEach((key) => {
@@ -46,7 +46,7 @@ const getTranslationsForLanguages = (fromLang, toLang, word) => {
 export const Search = () => {
     // use React state variables to return dynamic dictionaries
     const [translationResults, setTranslationResults] = useState({});
-
+    
     const searchForTranslations = (e) => {
         e.preventDefault();
 
@@ -67,7 +67,7 @@ export const Search = () => {
             // Display translations to the user as needed
             console.log(translationsDictionary);
             setTranslationResults(translationsDictionary);
-
+        
         } else {
             var error = {0:['000', 'Please select both From and To languages.']}
             setTranslationResults(error)

--- a/src/components/client/Search.jsx
+++ b/src/components/client/Search.jsx
@@ -21,7 +21,7 @@ const getTranslationsForLanguages = (fromLang, toLang, word) => {
             {
                 const translateFrom = translationsCategory[fromLang];
                 const translateTo = translationsCategory[toLang];
-                
+
                 // define a dictionary to return as value
                 const relevantTranslations = {};
                 Object.keys(translateFrom).forEach((key) => {
@@ -46,7 +46,7 @@ const getTranslationsForLanguages = (fromLang, toLang, word) => {
 export const Search = () => {
     // use React state variables to return dynamic dictionaries
     const [translationResults, setTranslationResults] = useState({});
-    
+
     const searchForTranslations = (e) => {
         e.preventDefault();
 
@@ -67,7 +67,7 @@ export const Search = () => {
             // Display translations to the user as needed
             console.log(translationsDictionary);
             setTranslationResults(translationsDictionary);
-        
+
         } else {
             var error = {0:['000', 'Please select both From and To languages.']}
             setTranslationResults(error)
@@ -101,7 +101,7 @@ export const Search = () => {
 
             {/* Display translation results */}
             <h3>Translation Results</h3>
-            <ul>
+            <ul data-testid="translation-results">
                 {Object.entries(translationResults).map(([key, value]) => (
                     <li key = {key}> {value[1]} </li>
                 ))}

--- a/tests/about.spec.js
+++ b/tests/about.spec.js
@@ -1,0 +1,7 @@
+import { test, expect } from "@playwright/test";
+
+test("page opens", async ({ page }) => {
+  await page.goto("/about");
+  await expect(page).toHaveTitle("About Mish Friendly Food");
+  await expect(page.locator("h1")).toHaveText("About Mish Friendly Food");
+});

--- a/tests/index.spec.js
+++ b/tests/index.spec.js
@@ -1,0 +1,7 @@
+import { test, expect } from "@playwright/test";
+
+test("page opens", async ({ page }) => {
+  await page.goto("/");
+  await expect(page).toHaveTitle("Mish Friendly Food");
+  await expect(page.locator("h1")).toHaveText("Mish Friendly Food");
+});

--- a/tests/translations.spec.js
+++ b/tests/translations.spec.js
@@ -1,0 +1,40 @@
+import { test, expect } from "@playwright/test";
+
+test("page opens", async ({ page }) => {
+  await page.goto("/translations");
+  await expect(page).toHaveTitle("Mish Friendly Food");
+  await expect(page.locator("h1")).toHaveText("Translations");
+});
+
+test("has a search form", async ({ page }) => {
+  await page.goto("/translations");
+  await expect(page.locator("form")).toBeVisible();
+});
+
+test("can translate a word", async ({ page }) => {
+  await page.goto("/translations");
+
+  await page.getByLabel("From").selectOption("English");
+  await page.getByLabel("To").selectOption("German");
+  await page.getByLabel("Word").fill("milk");
+
+  await page.getByRole("button", { name: "Translate" }).click();
+
+  await expect(
+    page.getByTestId("translation-results").locator("> li")
+  ).toHaveText([/Milch/, /Milchprodukt/]);
+});
+
+test("shows an error when there is no translation", async ({ page }) => {
+  await page.goto("/translations");
+
+  await page.getByLabel("From").selectOption("English");
+  await page.getByLabel("To").selectOption("Latin");
+  await page.getByLabel("Word").fill("milk");
+
+  await page.getByRole("button", { name: "Translate" }).click();
+
+  await expect(page.getByTestId("translation-results")).toHaveText(
+    /Translations not found for selected language combination/
+  );
+});


### PR DESCRIPTION
[Playwright](https://playwright.dev/) is a very popular end-to-end testing suite. We also have a need to get our functionality tested.

This pull request sets the project up with playwright 🎉 , that sets us up for future initiatives — and confidence that we continue to deliver a good customer experience. 

What you'll find is:

- **Brand new** `tests` folder that will house our end-to-end tests
- A script added to run them: `npm run e2e`
- Our GitHub actions updated, so as contributions come in GitHub can help us verify things wont regress.

What's next; get more testing coverage, and profit!?

fixes: https://github.com/mishmanners/mish-friendly-food/issues/109